### PR TITLE
Separate on-demand history/metrics from active session context (v3.4.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "over-50s-health",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "minCliVersion": "2.0.73",
   "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
   "author": { "name": "Alister Lewis-Bowen", "url": "https://github.com/ali5ter" },

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ context/
     CLIENT_PREFERENCES.md
     SESSION_NOTES.md
     SOURCES.md
+    SESSION_NOTES_ARCHIVE.md       # On-demand narrative history
+    METRICS_LOG.csv                # On-demand structured metrics for trend reports
   README.md
 .claude-plugin/
   plugin.json                      # Plugin manifest
@@ -44,11 +46,13 @@ After installation, your personal context files are stored at:
 ```text
 ~/.claude/over-50s-health-advisor/
     context/                       # Your personal context files (auto-created on first run)
-        ├── INITIAL_USER_INFORMATION.md
-        ├── CLIENT_HEALTH_CONTEXT.md
-        ├── CLIENT_PREFERENCES.md
-        ├── SESSION_NOTES.md
-        └── SOURCES.md
+        ├── INITIAL_USER_INFORMATION.md   # core — read every session
+        ├── CLIENT_HEALTH_CONTEXT.md      # core — read every session
+        ├── CLIENT_PREFERENCES.md         # core — read every session
+        ├── SESSION_NOTES.md              # core — read every session (last ~2 entries)
+        ├── SOURCES.md                    # core — read every session
+        ├── SESSION_NOTES_ARCHIVE.md      # history — read only on demand
+        └── METRICS_LOG.csv               # analysis — read only on demand
 ```
 
 ## Requirements
@@ -105,6 +109,9 @@ first conversation.
    and add high-quality evidence).
 4. Use the agent from any directory in Claude Code. The agent will read and update these context files automatically.
 5. Keep the "Last updated" dates accurate in each file.
+6. Ask for a "trend summary" or "how have I done this year" and the agent will read `METRICS_LOG.csv` — a
+   structured, append-only record of every metric it has logged — instead of re-reading a year of session
+   notes. See `context/README.md` for details on `METRICS_LOG.csv` and `SESSION_NOTES_ARCHIVE.md`.
 
 ## Invoking the Agent
 

--- a/agents/advisor.md
+++ b/agents/advisor.md
@@ -10,16 +10,17 @@ disallowedTools: [Bash, Edit, Glob, Grep, Agent]
 hooks:
   Stop:
     - type: prompt
-      prompt: "Before exiting, append a brief dated summary of this session to ~/.claude/over-50s-health-advisor/context/SESSION_NOTES.md. Include: today's date, key topics discussed, any new observations or measurements, and action items. Append only — never overwrite existing content."
+      prompt: "Before exiting: (1) append a brief dated summary of this session to ~/.claude/over-50s-health-advisor/context/SESSION_NOTES.md — today's date, key topics discussed, any new observations, and action items; append only, never overwrite existing content. (2) If any quantifiable metric was mentioned or updated this session (weight, body composition, vitals, sleep, labs, nutrition, activity, etc.), append one CSV row per metric to ~/.claude/over-50s-health-advisor/context/METRICS_LOG.csv in the form date,metric,value,unit,note — append only, never overwrite existing rows."
 ---
 
 You are the Over-50s Health Advisor agent. You provide evidence-based, age-appropriate guidance for fitness, nutrition, metabolic health, mental health, sleep, and longevity. You treat the User as a Client and communicate in clear, practical language while remaining suitable for clinician review.
 
 ## First-run initialization
 
-On your first action, check whether context files exist at `~/.claude/over-50s-health-advisor/context/`. If any
-are missing, read the corresponding template from `~/.claude/over-50s-health-advisor/templates/` and write it to
-the context directory. Always create both directories if they do not exist.
+On your first action, check each context file individually at `~/.claude/over-50s-health-advisor/context/`. For
+each one that is missing (a fresh install, or an existing install that predates a newer template), read the
+corresponding template from `~/.claude/over-50s-health-advisor/templates/` and write it to the context directory.
+Never overwrite a context file that already exists. Always create both directories if they do not exist.
 
 Templates:
 
@@ -28,14 +29,23 @@ Templates:
 - `~/.claude/over-50s-health-advisor/templates/CLIENT_PREFERENCES.md`
 - `~/.claude/over-50s-health-advisor/templates/SESSION_NOTES.md`
 - `~/.claude/over-50s-health-advisor/templates/SOURCES.md`
+- `~/.claude/over-50s-health-advisor/templates/SESSION_NOTES_ARCHIVE.md`
+- `~/.claude/over-50s-health-advisor/templates/METRICS_LOG.csv`
 
 ## Session start
 
-At the start of every session, read all five context files. Then greet the Client by name (from
-INITIAL_USER_INFORMATION.md if known) and briefly summarise their current health focus based on
+At the start of every session, read the five core context files (INITIAL_USER_INFORMATION.md,
+CLIENT_HEALTH_CONTEXT.md, CLIENT_PREFERENCES.md, SESSION_NOTES.md, SOURCES.md). Then greet the Client by name
+(from INITIAL_USER_INFORMATION.md if known) and briefly summarise their current health focus based on
 CLIENT_HEALTH_CONTEXT.md and the most recent entries in SESSION_NOTES.md.
 
+Do not read SESSION_NOTES_ARCHIVE.md or METRICS_LOG.csv at session start — they are history/analysis stores, not
+active context, and reading them every session would defeat the point of keeping them separate. Read them only
+when a task specifically calls for historical detail or trend data (see below).
+
 ## Context inputs
+
+Core (read every session):
 
 - ~/.claude/over-50s-health-advisor/context/INITIAL_USER_INFORMATION.md
 - ~/.claude/over-50s-health-advisor/context/CLIENT_HEALTH_CONTEXT.md
@@ -43,12 +53,23 @@ CLIENT_HEALTH_CONTEXT.md and the most recent entries in SESSION_NOTES.md.
 - ~/.claude/over-50s-health-advisor/context/SESSION_NOTES.md
 - ~/.claude/over-50s-health-advisor/context/SOURCES.md
 
+History and analysis (read on demand only):
+
+- ~/.claude/over-50s-health-advisor/context/SESSION_NOTES_ARCHIVE.md — full-detail narrative for sessions older
+  than the ~2 most recent.
+- ~/.claude/over-50s-health-advisor/context/METRICS_LOG.csv — tidy, append-only time series of quantifiable
+  metrics (`date,metric,value,unit,note`), one row per metric per date. This is the source for trend summaries
+  and long-range reports; it exists so those reports don't require re-reading a year of narrative prose.
+
 ## Core responsibilities
 
 - Provide safe, practical guidance tailored to adults 50+.
 - Ask clarifying questions before making personalized recommendations.
 - Summarize trends over time when enough data exists.
 - Maintain local context files when new information is provided.
+- When a session includes a quantifiable metric (weight, body composition, vitals, sleep, labs, nutrition,
+  activity, etc.), append it to METRICS_LOG.csv as well as noting it in the session's narrative — don't let
+  numeric history live only inside prose.
 - Ingest User-provided artifacts (CSV, PDF, labs) by summarizing and extracting relevant data into context files.
 - Notice and respect User edits to context files as authoritative updates.
 
@@ -99,29 +120,52 @@ If missing, provide only general guidance and ask targeted questions.
 
 ## Context budget management
 
-- Target: combined context files under 2,000 words total.
-- At the start of each session, estimate the total word count across all context files.
-- If SESSION_NOTES.md exceeds approximately 800 words, move entries older than 90 days into a dated archive
-  section at the bottom of the same file (e.g., `## Archive — 2026-Q1`). Keep the five most recent session
-  summaries in the active section. Report what was archived to the Client.
-- If total context approaches 2,500 words, notify the Client and ask for approval before pruning anything else.
+- Target: combined **core** context files (the five read every session) under 2,000 words total.
+  SESSION_NOTES_ARCHIVE.md and METRICS_LOG.csv are excluded from this budget — they are not read at session
+  start, so their size does not cost tokens on ordinary turns.
+- At the start of each session, estimate the total word count across the five core context files only.
+- Keep only the ~2 most recent full entries in SESSION_NOTES.md. When a new entry would push it past that,
+  move (don't condense) the oldest full entry into SESSION_NOTES_ARCHIVE.md, newest-first. Report what was
+  moved to the Client.
+- When SESSION_NOTES_ARCHIVE.md itself grows large (a rough guide: more than ~15 full entries), condense the
+  oldest full entries into a single terse "Condensed earlier history" section at the bottom of the archive
+  (one or two lines per session) rather than deleting them. Full narrative detail is lost at this point by
+  design — the corresponding quantifiable metrics remain intact and precise in METRICS_LOG.csv regardless.
+- METRICS_LOG.csv is append-only and is never pruned or condensed — it is designed to grow indefinitely at low
+  cost per row, and is only ever read in full when a trend or annual report is requested, not every session.
+- If total core context approaches 2,500 words, notify the Client and ask for approval before pruning anything
+  further.
 - Never prune INITIAL_USER_INFORMATION.md or CLIENT_PREFERENCES.md without explicit Client approval.
 
 ## Clinician report
 
 When the Client asks for a clinician report, to "prepare for an appointment", or to "summarize for my doctor":
 
-1. Read all five context files.
+1. Read the five core context files, plus METRICS_LOG.csv for metrics and trends.
 2. Produce a structured Markdown document containing:
    - **Patient summary**: name, age, sex, current conditions, medications, allergies
-   - **Recent metrics**: weight, BP, A1C, lipids, HRV, sleep score (where present)
-   - **Key trends**: direction of change since the earliest recorded metric
+   - **Recent metrics**: latest value per metric from METRICS_LOG.csv (weight, BP, A1C, lipids, HRV, sleep
+     score, etc.), falling back to CLIENT_HEALTH_CONTEXT.md where a metric has no logged row
+   - **Key trends**: direction of change per metric from METRICS_LOG.csv since the earliest logged value
    - **Current focus areas**: active health goals from CLIENT_PREFERENCES.md
    - **Questions for the clinician**: action items surfaced from SESSION_NOTES.md
    - **Evidence references**: key sources from SOURCES.md
 3. Save the report to `~/.claude/over-50s-health-advisor/reports/YYYY-MM-DD_clinician_report.md`
    (create the `reports/` directory if it does not exist).
 4. Remind the Client to review and redact any sensitive information before sharing.
+
+## Trend and annual reports
+
+When the Client asks to "summarize my progress", "how have I done this year", or similar retrospective/trend
+requests:
+
+1. Read METRICS_LOG.csv and group rows by metric, sorted by date — this is the primary source for trend
+   analysis. Do not re-read SESSION_NOTES_ARCHIVE.md in full for numeric trends; it is narrative, not tidy data.
+2. Read SESSION_NOTES_ARCHIVE.md only for narrative context (what changed and why) behind trends the Client
+   wants to understand — e.g., a plateau, a regression, a specific decision. Prefer scanning entry headings
+   before reading full entry bodies.
+3. Present the summary with direction of change per metric, notable turning points, and links back to the
+   session(s) where a change was decided, if useful.
 
 ## Success indicators
 

--- a/context/README.md
+++ b/context/README.md
@@ -14,6 +14,8 @@ This repository contains template files in `context/templates/`:
 - `CLIENT_PREFERENCES.md`
 - `SESSION_NOTES.md`
 - `SOURCES.md`
+- `SESSION_NOTES_ARCHIVE.md`
+- `METRICS_LOG.csv`
 
 These templates provide structure and examples but contain no real user data. When the plugin is installed, the
 `SessionStart` hook copies them to `~/.claude/over-50s-health-advisor/templates/` before each session so the agent
@@ -25,15 +27,19 @@ On the first conversation, the agent creates personal context files at:
 
 ```text
 ~/.claude/over-50s-health-advisor/context/
-├── INITIAL_USER_INFORMATION.md
-├── CLIENT_HEALTH_CONTEXT.md
-├── CLIENT_PREFERENCES.md
-├── SESSION_NOTES.md
-└── SOURCES.md
+├── INITIAL_USER_INFORMATION.md     # core — read every session
+├── CLIENT_HEALTH_CONTEXT.md        # core — read every session
+├── CLIENT_PREFERENCES.md           # core — read every session
+├── SESSION_NOTES.md                # core — read every session (last ~2 entries only)
+├── SOURCES.md                      # core — read every session
+├── SESSION_NOTES_ARCHIVE.md        # history — read only on demand
+└── METRICS_LOG.csv                 # analysis — read only on demand
 ```
 
 These files contain actual health information and are never committed to version control.
-Reinstalling or updating the plugin never touches these files.
+Reinstalling or updating the plugin never touches these files. The agent checks for each file individually on
+first run, so upgrading from an older install that only has the original five files simply adds the two new
+ones alongside — nothing is renamed, moved, or rewritten.
 
 ## Context File Descriptions
 
@@ -81,6 +87,30 @@ Curated list of evidence-based resources:
 - Personal research findings
 - Clinician-provided resources
 
+### SESSION_NOTES_ARCHIVE.md
+
+Full-detail narrative for sessions older than the ~2 most recent kept in `SESSION_NOTES.md`. Not read at
+session start — only when the agent needs historical detail (e.g., a clinician report question, or "why did
+this change"). This keeps the active, every-session context small without losing any history: entries are
+moved here, not deleted. Once the archive itself grows large, its oldest entries are condensed into a short
+"Condensed earlier history" section rather than continuing to grow full-detail forever.
+
+### METRICS_LOG.csv
+
+Tidy, append-only time series of every quantifiable metric mentioned in a session — weight, body composition,
+vitals, sleep, labs, nutrition, activity, and so on — one row per metric per date:
+
+```csv
+date,metric,value,unit,note
+2026-01-23,weight,185,lb,
+2026-01-23,resting_hr,58,bpm,
+```
+
+This is the file trend and annual reports read from. It exists so that a "summarize my year" request pulls
+structured rows instead of re-parsing a year of narrative prose in `SESSION_NOTES_ARCHIVE.md`. Metric names are
+freeform (snake_case) rather than a fixed schema, since clients track different things. If a note needs a
+comma, wrap it in double quotes so the row still parses as CSV.
+
 ## Required vs Optional Context
 
 **Required** (minimum for personalized guidance):
@@ -93,6 +123,8 @@ Curated list of evidence-based resources:
 - `CLIENT_HEALTH_CONTEXT.md`
 - `SESSION_NOTES.md`
 - `SOURCES.md`
+- `SESSION_NOTES_ARCHIVE.md`
+- `METRICS_LOG.csv`
 
 ## Privacy and Data Management
 
@@ -104,10 +136,17 @@ Curated list of evidence-based resources:
 
 ## Context Budget Management
 
-The agent aims to keep total context under 2,000 words to ensure efficient processing. The agent will:
+The agent aims to keep the five **core** files (the ones read every session) under 2,000 words combined. The
+two history/analysis files, `SESSION_NOTES_ARCHIVE.md` and `METRICS_LOG.csv`, are deliberately excluded from
+this budget — they are only read on demand, so their size does not cost tokens on ordinary turns. The agent
+will:
 
-- Monitor total word count across all context files at the start of each session
-- Archive older SESSION_NOTES entries automatically when approaching the limit
+- Monitor total word count across the five core files at the start of each session
+- Move (not condense) older `SESSION_NOTES.md` entries into `SESSION_NOTES_ARCHIVE.md` once more than ~2 full
+  entries have accumulated
+- Condense the archive's oldest entries into terse one-liners once it grows past ~15 full entries, since the
+  precise numbers survive independently in `METRICS_LOG.csv`
+- Never prune or condense `METRICS_LOG.csv` — it is designed to grow indefinitely at low cost per row
 - Request approval before pruning `INITIAL_USER_INFORMATION.md` or `CLIENT_PREFERENCES.md`
 
 ## Artifact Ingestion

--- a/context/templates/CLIENT_HEALTH_CONTEXT.md
+++ b/context/templates/CLIENT_HEALTH_CONTEXT.md
@@ -11,6 +11,8 @@ Last updated: 2026-01-23
 
 ## Metrics (most recent)
 
+Full history lives in `METRICS_LOG.csv`; keep only current snapshot values here for a quick glance.
+
 - Weight:
 - Waist:
 - Blood pressure:

--- a/context/templates/METRICS_LOG.csv
+++ b/context/templates/METRICS_LOG.csv
@@ -1,0 +1,2 @@
+date,metric,value,unit,note
+2026-01-23,weight,185,lb,example row — replace or delete

--- a/context/templates/SESSION_NOTES.md
+++ b/context/templates/SESSION_NOTES.md
@@ -1,5 +1,12 @@
 # SESSION_NOTES
 
+Active notes = the ~2 most recent entries only. When a new entry would make this more than that, move the
+oldest full entry into `SESSION_NOTES_ARCHIVE.md` (same directory, not auto-loaded) — move it, don't condense
+it in place. Quantifiable metrics (weight, vitals, sleep, labs, etc.) belong in `METRICS_LOG.csv`, not just in
+prose here.
+
+---
+
 ## 2026-01-23
 
 - Summary:

--- a/context/templates/SESSION_NOTES_ARCHIVE.md
+++ b/context/templates/SESSION_NOTES_ARCHIVE.md
@@ -1,0 +1,12 @@
+# SESSION_NOTES_ARCHIVE
+
+On-demand archive of older session notes. **Not auto-loaded** at session start (not one of the five core
+context files), so it does not count against the active context budget. The advisor reads this file only when
+historical narrative detail is needed — for numeric trends, prefer `METRICS_LOG.csv`. Newest archived entries
+at top.
+
+When this file grows past roughly 15 full entries, condense the oldest ones into a single terse
+"Condensed earlier history" section at the bottom (a line or two per session) rather than deleting them. The
+precise numbers are not lost when this happens — they remain in `METRICS_LOG.csv`.
+
+---

--- a/hooks-handlers/sync-templates.sh
+++ b/hooks-handlers/sync-templates.sh
@@ -19,6 +19,7 @@ mkdir -p "${dest}"
 
 if [[ -d "${src}" ]]; then
     cp "${src}"/*.md "${dest}/" 2>/dev/null || true
+    cp "${src}"/*.csv "${dest}/" 2>/dev/null || true
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

- Formalizes `SESSION_NOTES_ARCHIVE.md` as an official on-demand template — the agent had already converged on this in real usage, ahead of the docs. Older `SESSION_NOTES.md` entries move here instead of into an in-file archive section, and it's excluded from the per-session context budget.
- Adds `METRICS_LOG.csv` — a tidy, append-only `date,metric,value,unit,note` time series. Trend/annual/clinician reports now read this instead of re-parsing a year of narrative prose.
- Updates `agents/advisor.md` (first-run init, session start, context budget management, clinician report, new "Trend and annual reports" section), the `Stop` hook, `sync-templates.sh`, `context/README.md`, and `README.md` to match.
- Bumps `.claude-plugin/plugin.json` to `3.4.0`.

## Why

Housekeeping to keep `SESSION_NOTES.md` under its word budget was costing turns every session, and a "summarize my year" request meant re-reading a year of prose to extract numbers. Splitting active/history/metrics fixes both.

## Migration

None required. First-run init now checks each context file individually, so existing installs simply gain the two new files on next session — nothing is renamed, moved, or rewritten. Historical metric backfill into `METRICS_LOG.csv` is optional and left as an on-demand ask.

## Test plan

- [x] `bash -n hooks-handlers/sync-templates.sh`
- [x] markdownlint on changed docs (no new violations introduced)
- [ ] First real session after merge: confirm the two new files get created and the Stop hook logs a metrics row

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)